### PR TITLE
docs: fix spelling of 'necessary'

### DIFF
--- a/Cleansing/README.md
+++ b/Cleansing/README.md
@@ -25,7 +25,7 @@
 	- `dic_CITY_DISTRICT_WARD`, `dic_CITY_DISTRICT_STREET`: dic wards or streets in districts, districts in cities, with with key1 = 'thanhpho', key2 = 'Hà Nội', key3 = 'quan', key4 = 'ba dinh', key5 = 'phuong' and value = list ward or list streets. Example: data["thanhpho"]["Hà Nội"]["quan"]["Ba Đình"]["phuong"] 
 	- `dic_combine_level`: dic wards or streets in districts, districts in cities in unidecode format, with key1 = 'thanh pho ho chi minh', key2 = 'quan 3'
 -  clean_site.py: the script used for cleaning each site
--  create_dic.py: create neccessary dictionaries for split address
+-  create_dic.py: create necessary dictionaries for split address
 -  pre_visualize.py: the script for checking after crawling or cleansing each site
 -  data_backup.py: the script backup records cleaned to backup table
 -  requirements.txt: contains all libraries with versions

--- a/scrapy/VN_BATDONGSAN/README.md
+++ b/scrapy/VN_BATDONGSAN/README.md
@@ -22,7 +22,7 @@ all category finish, we will have full project extract.tab file in DELTA folder.
         2. Extract total number of index-pages N need to download,
         3. Download all index-pages html file (from page 1 to N) and store it
         in LIST_MODE folder
-        3. Parsing the neccessary data from all page-index html file and save it
+        3. Parsing the necessary data from all page-index html file and save it
         to extract tab.
 
 **Step 3:** Download detail pages by reading need_download.tab file in DELTA folder

--- a/scrapy/VN_RONGBAY/README.md
+++ b/scrapy/VN_RONGBAY/README.md
@@ -26,7 +26,7 @@ strategy crawling as below.
         3. Extract total number of index-pages N need to download,
         4. Download all index-pages html file (from page 1 to N) and store it
         in LIST_MODE folder
-        5. Parsing the neccessary data from all page-index html file and save it
+        5. Parsing the necessary data from all page-index html file and save it
         to extract tab.
 
 **2.3.** Create need_download.tab which include only newly created ads.

--- a/scrapy/VN_TINBATDONGSAN/README.md
+++ b/scrapy/VN_TINBATDONGSAN/README.md
@@ -33,7 +33,7 @@ strategy crawling as below.
         2. Extract total number of index-pages N need to download,
         3. Download all index-pages html file (from page 1 to N) and store it
         in LIST_MODE folder
-        3. Parsing the neccessary data from all page-index html file and save it
+        3. Parsing the necessary data from all page-index html file and save it
         to extract tab.
 
 **Step 3:** Download detail pages by reading need_download.tab file in DELTA folder


### PR DESCRIPTION
## Summary
- fix misspelling of "necessary" across README files

## Testing
- `grep -RIn neccessary --line-number`

------
https://chatgpt.com/codex/tasks/task_e_68899476cb308326836e068dde10bd51