### PR TITLE
Fix Python syntax error

### DIFF
--- a/scrapy/VN_DOTHINET/get_list_from_json.py
+++ b/scrapy/VN_DOTHINET/get_list_from_json.py
@@ -63,7 +63,7 @@ while (index < len(data)):
     query_insert = str(city_name)+'-'+str(prefix_city)
     
     index = index + 1
-    print query_insert.lower()
+    print(query_insert.lower())
     
     
     


### PR DESCRIPTION
## Summary
- fix Python 3 syntax in `get_list_from_json.py`

## Testing
- `python3 -m py_compile $(cat /tmp/pyfiles.txt)`

------
https://chatgpt.com/codex/tasks/task_e_68899263b584832683ce06f68db663a6